### PR TITLE
Corrected BB costs for Glyphs

### DIFF
--- a/src/javascript/data/tswcalc-data-costs.js
+++ b/src/javascript/data/tswcalc-data-costs.js
@@ -47,22 +47,22 @@ tswcalc.data.bb_costs = {
     },
     'glyph': {
         '10.0': {
-            cost: 30
+            cost: 0
         },
         '10.1': {
-            cost: 50
+            cost: 20
         },
         '10.2': {
-            cost: 70
+            cost: 40
         },
         '10.3': {
-            cost: 90
+            cost: 60
         },
         '10.4': {
-            cost: 110
+            cost: 80
         },
         '10.5': {
-            cost: 130,
+            cost: 100,
             astral_fuse: true
         }
     }


### PR DESCRIPTION
BB costs for glyphs are incorrect - the cost for a 10.0 talisman with a 10.0 glyph is 30BB, not 60 - the glyph requires a toolkit, but does not cost any BB to insert into the talisman. Reduced the cost of glyphs by 30BB to reflect the actual cost.

I can't get it to build on my machine, so I'm not sure if there are any tests that I should have changed.
