### PR TITLE
10.8 and 10.9 gear

### DIFF
--- a/src/javascript/data/tswcalc-data-costs.js
+++ b/src/javascript/data/tswcalc-data-costs.js
@@ -32,6 +32,16 @@ tswcalc.data.costs = {
             bullion: 2700,
             pantheon: 160,
             criterion_upgrade: true
+        },
+        '10.8': {
+            bullion: 3000,
+            pantheon: 280,
+            criterion_upgrade: true
+        },
+        '10.9': {
+            bullion: 3300,
+            pantheon: 400,
+            criterion_upgrade: true
         }
     },
     'talisman': {
@@ -62,6 +72,16 @@ tswcalc.data.costs = {
         '10.7': {
             bullion: 1700,
             pantheon: 140,
+            criterion_upgrade: true
+        },
+        '10.8': {
+            bullion: 2000,
+            pantheon: 250,
+            criterion_upgrade: true
+        },
+        '10.9': {
+            bullion: 2300,
+            pantheon: 360,
             criterion_upgrade: true
         }
     },
@@ -94,6 +114,14 @@ tswcalc.data.costs = {
         'superior_weapon_kit': {
             bullion: 300,
             pantheon: 80
+        },
+        'supernal_talisman_kit': {
+            bullion: 300,
+            pantheon: 110
+        },
+        'supernal_weapon_kit': {
+            bullion: 300,
+            pantheon: 120
         },
         'astral': {
             bullion: 250,

--- a/src/javascript/data/tswcalc-data-gear.js
+++ b/src/javascript/data/tswcalc-data-gear.js
@@ -26,6 +26,12 @@ tswcalc.data.custom_gear_data = {
         },
         '10.7': {
             weapon_power: 475
+        },
+        '10.8': {
+            weapon_power: 492
+        },
+        '10.9': {
+            weapon_power: 510
         }
     },
     'head': {
@@ -53,6 +59,12 @@ tswcalc.data.custom_gear_data = {
             },
             'ql10.7': {
                 rating: 936
+            },
+            'ql10.8': {
+                rating: 1011
+            },
+            'ql10.9': {
+                rating: 1077
             }
         },
         tank: {
@@ -79,6 +91,12 @@ tswcalc.data.custom_gear_data = {
             },
             'ql10.7': {
                 hitpoints: 2714
+            },
+            'ql10.8': {
+                hitpoints: 2864
+            },
+            'ql10.9': {
+                hitpoints: 3021
             }
         }
     },
@@ -107,6 +125,12 @@ tswcalc.data.custom_gear_data = {
             },
             'ql10.7': {
                 rating: 845
+            },
+            'ql10.8': {
+                rating: 913
+            },
+            'ql10.9': {
+                rating: 972
             }
         },
         tank: {
@@ -133,6 +157,12 @@ tswcalc.data.custom_gear_data = {
             },
             'ql10.7': {
                 hitpoints: 2452
+            },
+            'ql10.8': {
+                hitpoints: 2587
+            },
+            'ql10.9': {
+                hitpoints: 2728
             }
         }
     },
@@ -161,6 +191,12 @@ tswcalc.data.custom_gear_data = {
             },
             'ql10.7': {
                 rating: 543
+            },
+            'ql10.8': {
+                rating: 587
+            },
+            'ql10.9': {
+                rating: 625
             }
         },
         tank: {
@@ -187,6 +223,12 @@ tswcalc.data.custom_gear_data = {
             },
             'ql10.7': {
                 hitpoints: 1576
+            },
+            'ql10.8': {
+                hitpoints: 1663
+            },
+            'ql10.9': {
+                hitpoints: 1754
             }
         }
     }

--- a/src/javascript/tswcalc-buttonbar.js
+++ b/src/javascript/tswcalc-buttonbar.js
@@ -11,6 +11,7 @@ tswcalc.buttonBar = function() {
             btn_all_10_4: $('#btn-all-10-4'),
             btn_all_10_5: $('#btn-all-10-5'),
             btn_all_10_7: $('#btn-all-10-7'),
+            btn_all_10_9: $('#btn-all-10-9'),
             btn_reset: $('#btn-reset')
         };
     };
@@ -27,6 +28,7 @@ tswcalc.buttonBar = function() {
         el.btn_all_10_4.on('click', setQlOnAllSlots);
         el.btn_all_10_5.on('click', setQlOnAllSlots);
         el.btn_all_10_7.on('click', setQlOnAllSlots);
+        el.btn_all_10_9.on('click', setQlOnAllSlots);
         el.btn_reset.on('click', resetAllSlots);
     };
 

--- a/src/templates/dusts/buttonbar.dust
+++ b/src/templates/dusts/buttonbar.dust
@@ -10,6 +10,7 @@
   <button id="btn-all-10-4" class="btn">All 10.4</button>
   <button id="btn-all-10-5" class="btn">All 10.5</button>
   <button id="btn-all-10-7" class="btn">All 10.7</button>
+  <button id="btn-all-10-9" class="btn">All 10.9</button>
 </div>
 <div class="btn-group">
   <a class="btn btn-info dropdown-toggle" data-toggle="dropdown" href="#">

--- a/src/templates/dusts/qlselect.dust
+++ b/src/templates/dusts/qlselect.dust
@@ -8,5 +8,7 @@
     {?is_item}
     <option value="10.6">10.6</option>
     <option value="10.7">10.7</option>
+    <option value="10.8">10.8</option>
+    <option value="10.9">10.9</option>
     {/is_item}
 </select>


### PR DESCRIPTION
11.0 is technically available on Test Live too, but 11.0 seemingly requires a raid drop so I can't see values or anything.

Also, I have a feeling 11.0 is going to require some refactoring, because there's a few things that just assume a "10." is in the front... could possibly cheat this by using 10.10 behind the scenes (as long as Funcom never takes us higher than 11.0) but I'm not sure I like that.