### PR TITLE
10.9 NY Minors

### DIFF
--- a/public/assets/stylesheets/tswcalc.css
+++ b/public/assets/stylesheets/tswcalc.css
@@ -171,3 +171,7 @@ div .slot {
 #table-primary .tooltip.left{
     margin-left: -12px
 }
+
+option:disabled {
+    display:none;
+}

--- a/src/javascript/data/tswcalc-data-items.js
+++ b/src/javascript/data/tswcalc-data-items.js
@@ -123,7 +123,7 @@ tswcalc.data.items = [
     {
         id: '86',
         name: 'Subway Tokens',
-        ql: '10.4',
+        ql: ['10.4', '10.9'],
         slots: ['luck'],
         role: 'dps',
         signet: {
@@ -136,7 +136,7 @@ tswcalc.data.items = [
     {
         id: '87',
         name: 'NY Buckle',
-        ql: '10.4',
+        ql: ['10.4', '10.9'],
         slots: ['waist'],
         role: 'tank',
         signet: {
@@ -153,7 +153,7 @@ tswcalc.data.items = [
     {
         id: '88',
         name: 'Broadway Charm',
-        ql: '10.4',
+        ql: ['10.4', '10.9'],
         slots: ['occult'],
         role: 'healer',
         signet: {

--- a/src/javascript/tswcalc-selects.js
+++ b/src/javascript/tswcalc-selects.js
@@ -182,9 +182,20 @@ tswcalc.select.SelectHandler = function SelectHandler(slot) {
     this.updateControlsForItem = function() {
         var item = slotObj.item();
         slotObj.name(': ' + item.name);
-        if(item.ql) { 
-            slotObj.ql(item.ql);
-            slotObj.el.ql.attr('disabled', 'disabled');
+        if(item.ql) {
+            if(Array.isArray(item.ql)) {
+                slotObj.el.ql.find('option').each(function(idx, qlOption) {
+                    if(item.ql.indexOf(qlOption.value) == -1) {
+                        if(slotObj.ql() == qlOption.value) {
+                            slotObj.ql(item.ql[0]);
+                        }
+                        $(this).attr('disabled', 'disabled');
+                    }
+                });
+            } else {
+                slotObj.ql(item.ql);
+                slotObj.el.ql.attr('disabled', 'disabled');
+            }
         }
         if(item.glyph) {
             slotObj.glyphQl(item.glyph.ql);
@@ -235,6 +246,7 @@ tswcalc.select.SelectHandler = function SelectHandler(slot) {
         slotObj.el.primaryGlyph.removeAttr('disabled');
         slotObj.el.secondaryGlyph.removeAttr('disabled');
         slotObj.el.ql.removeAttr('disabled');
+        slotObj.el.ql.find('option[disabled]').removeAttr('disabled');
         slotObj.el.signetId.removeAttr('disabled');
         if(slotObj.signetQuality() === 'heroic') {
             slotObj.signetQuality('none');

--- a/src/javascript/tswcalc-slots.js
+++ b/src/javascript/tswcalc-slots.js
@@ -398,6 +398,7 @@ tswcalc.slots.Slot = function Slot(id, name, group) {
         this.wtype('none');
         this.ql('10.0');
         this.itemId('3');
+        this.el.itemId.change();
         this.glyphQl('10.0');
         this.primaryGlyph('none');
         this.secondaryGlyph('none');
@@ -407,7 +408,6 @@ tswcalc.slots.Slot = function Slot(id, name, group) {
         this.el.btn.primary[4].trigger('click');
         this.el.btn.secondary[0].trigger('click');
         this.el.glyphQl.change();
-        this.el.itemId.change();
     };
 
     this.state = function() {

--- a/test/application.js
+++ b/test/application.js
@@ -12,7 +12,7 @@ test('should initate tswcalc submodules', 8, function() {
     ok(tswcalc.import);
 });
 
-test('should import pre-1.3 build from hash', 113, function() {
+test('should import pre-1.3 build from hash', 119, function() {
     location.hash = 'weapon=5,5,4,4,0,4,0,2,5&head=4,1,5,5,0,4,0,3,18&ring=4,2,4,1,0,4,0,3,83&neck=4,1,5,5,0,4,0,1,21&wrist=4,1,4,6,0,4,0,3,85&luck=4,3,4,8,0,4,0,3,39&waist=4,1,4,8,0,4,0,3,87&occult=4,2,4,1,0,4,0,3,88';
     tswcalc.init();
 
@@ -127,7 +127,10 @@ test('should import pre-1.3 build from hash', 113, function() {
     equal($('#waist-signet-quality').val(), 'epic');
     ok($('#waist-signet-quality').attr('disabled'));
     ok($('#waist-pick-signet').attr('disabled'));
-    ok($('#waist-ql').attr('disabled'));
+    ok($('#waist-ql option[value="10.1"]').attr('disabled'));
+    ok($('#waist-ql option[value="10.7"]').attr('disabled'));
+    ok(!$('#waist-ql option[value="10.4"]').attr('disabled'));
+    ok(!$('#waist-ql option[value="10.9"]').attr('disabled'));
 
     equal($('#occult-name').html(), ': Broadway Charm');
     equal($('#occult-ql').val(), '10.4');
@@ -140,10 +143,13 @@ test('should import pre-1.3 build from hash', 113, function() {
     equal($('#occult-signet-quality').val(), 'epic');
     ok($('#occult-signet-quality').attr('disabled'));
     ok($('#occult-pick-signet').attr('disabled'));
-    ok($('#occult-ql').attr('disabled'));
+    ok($('#occult-ql option[value="10.1"]').attr('disabled'));
+    ok($('#occult-ql option[value="10.7"]').attr('disabled'));
+    ok(!$('#occult-ql option[value="10.4"]').attr('disabled'));
+    ok(!$('#occult-ql option[value="10.9"]').attr('disabled'));
 });
 
-test('should import post-1.3 build from hash', 113, function() {
+test('should import post-1.3 build from hash', 119, function() {
     location.hash = 'weapon=5,5,4,4,0,4,0,2,5&weapon2=5,3,4,1,2,2,2,3,15&head=4,1,5,5,0,4,0,3,18&ring=4,2,4,1,0,4,0,3,83&neck=4,1,5,5,0,4,0,1,21&wrist=4,1,4,6,0,4,0,3,85&luck=4,3,4,8,0,4,0,3,39&waist=4,1,4,8,0,4,0,3,87&occult=4,2,4,1,0,4,0,3,88';
     tswcalc.init();
 
@@ -258,7 +264,10 @@ test('should import post-1.3 build from hash', 113, function() {
     equal($('#waist-signet-quality').val(), 'epic');
     ok($('#waist-signet-quality').attr('disabled'));
     ok($('#waist-pick-signet').attr('disabled'));
-    ok($('#waist-ql').attr('disabled'));
+    ok($('#waist-ql option[value="10.1"]').attr('disabled'));
+    ok($('#waist-ql option[value="10.7"]').attr('disabled'));
+    ok(!$('#waist-ql option[value="10.4"]').attr('disabled'));
+    ok(!$('#waist-ql option[value="10.9"]').attr('disabled'));
 
     equal($('#occult-name').html(), ': Broadway Charm');
     equal($('#occult-ql').val(), '10.4');
@@ -271,5 +280,8 @@ test('should import post-1.3 build from hash', 113, function() {
     equal($('#occult-signet-quality').val(), 'epic');
     ok($('#occult-signet-quality').attr('disabled'));
     ok($('#occult-pick-signet').attr('disabled'));
-    ok($('#occult-ql').attr('disabled'));
+    ok($('#occult-ql option[value="10.1"]').attr('disabled'));
+    ok($('#occult-ql option[value="10.7"]').attr('disabled'));
+    ok(!$('#occult-ql option[value="10.4"]').attr('disabled'));
+    ok(!$('#occult-ql option[value="10.9"]').attr('disabled'));
 });

--- a/test/import.js
+++ b/test/import.js
@@ -10,7 +10,7 @@ module('import-integration-tests', {
     }
 });
 
-test('should import URL and set summary and slots for 0.4.0 links', 91, function() {
+test('should import URL and set summary and slots for 0.4.0 links', 94, function() {
     var vars = {
         head: '4,1,5,5,0,4,0',
         luck: '4,3,4,8,0,4,0',
@@ -115,7 +115,10 @@ test('should import URL and set summary and slots for 0.4.0 links', 91, function
     equal($('#waist-signet-quality').val(), 'epic');
     ok($('#waist-signet-quality').attr('disabled'));
     ok($('#waist-pick-signet').attr('disabled'));
-    ok($('#waist-ql').attr('disabled'));
+    ok($('#waist-ql option[value="10.1"]').attr('disabled'));
+    ok($('#waist-ql option[value="10.7"]').attr('disabled'));
+    ok(!$('#waist-ql option[value="10.4"]').attr('disabled'));
+    ok(!$('#waist-ql option[value="10.9"]').attr('disabled'));
 
     equal($('#occult-ql').val(), '10.4');
     equal($('#occult-itemId').val(), '3');
@@ -128,7 +131,7 @@ test('should import URL and set summary and slots for 0.4.0 links', 91, function
     equal($('#occult-pick-signet').val(), 'none');
 });
 
-test('should import URL and set summary and slots for pre-1.3 links', 95, function() {
+test('should import URL and set summary and slots for pre-1.3 links', 98, function() {
     var vars = {
         head: '4,1,5,5,0,4,0,3,18',
         luck: '4,3,4,8,0,4,0,3,39',
@@ -237,7 +240,10 @@ test('should import URL and set summary and slots for pre-1.3 links', 95, functi
     equal($('#waist-signet-quality').val(), 'epic');
     ok($('#waist-signet-quality').attr('disabled'));
     ok($('#waist-pick-signet').attr('disabled'));
-    ok($('#waist-ql').attr('disabled'));
+    ok($('#waist-ql option[value="10.1"]').attr('disabled'));
+    ok($('#waist-ql option[value="10.7"]').attr('disabled'));
+    ok(!$('#waist-ql option[value="10.4"]').attr('disabled'));
+    ok(!$('#waist-ql option[value="10.9"]').attr('disabled'));
 
     equal($('#occult-ql').val(), '10.4');
     equal($('#occult-itemId').val(), '3');
@@ -250,14 +256,14 @@ test('should import URL and set summary and slots for pre-1.3 links', 95, functi
     equal($('#occult-pick-signet').val(), '41');
 });
 
-test('should import URL and set summary and slots for 1.3 links (secondary weapon added)', 107, function() {
+test('should import URL and set summary and slots for 1.3 links (secondary weapon added)', 110, function() {
     var vars = {
         head: '4,1,5,5,0,4,0,3,18',
         luck: '4,3,4,8,0,4,0,3,39',
         neck: '4,1,5,5,0,4,0,1,21',
         occult: '4,3,4,4,0,4,0,3,41',
         ring: '4,3,4,6,0,4,0,2,22',
-        waist: '4,1,4,8,0,4,0,3,87',
+        waist: '9,1,4,8,0,4,0,3,87',
         weapon: '5,1,4,4,0,4,0,2,5',
         weapon2: '5,2,4,4,0,4,0,2,6',
         wrist: '4,1,4,6,0,4,0,3,85'
@@ -266,7 +272,7 @@ test('should import URL and set summary and slots for 1.3 links (secondary weapo
     tswcalc.import.start(vars);
 
     // Summary
-    equal($('#stat-hitpoints').html(), '10788');
+    equal($('#stat-hitpoints').html(), '11104');
     equal($('#stat-combat-power').html(), '504');
     equal($('#stat-attack-rating').html(), '1565');
     equal($('#stat-weapon-power').html(), '457');
@@ -363,7 +369,7 @@ test('should import URL and set summary and slots for 1.3 links (secondary weapo
 
     //NY Buckle
     equal($('#waist-name').html(), ': NY Buckle');
-    equal($('#waist-ql').val(), '10.4');
+    equal($('#waist-ql').val(), '10.9');
     equal($('#waist-itemId').val(), '87');
     equal($('#waist-glyph-ql').val(), '10.4');
     equal($('#waist-primary-glyph').val(), 'physical-protection');
@@ -373,7 +379,10 @@ test('should import URL and set summary and slots for 1.3 links (secondary weapo
     equal($('#waist-signet-quality').val(), 'epic');
     ok($('#waist-signet-quality').attr('disabled'));
     ok($('#waist-pick-signet').attr('disabled'));
-    ok($('#waist-ql').attr('disabled'));
+    ok($('#waist-ql option[value="10.1"]').attr('disabled'));
+    ok($('#waist-ql option[value="10.7"]').attr('disabled'));
+    ok(!$('#waist-ql option[value="10.4"]').attr('disabled'));
+    ok(!$('#waist-ql option[value="10.9"]').attr('disabled'));
 
     equal($('#occult-ql').val(), '10.4');
     equal($('#occult-itemId').val(), '3');


### PR DESCRIPTION
Patch for 10.9 NY minor pieces. These are the only ones to have dropped so far, but the framework is there now, so it will be as simple as adding the other QL to the data entries later for majors/head.

Also, all disabled options are now hidden in dropdowns to make selection cleaner. An additional upside is that "Heroic" no longer erroneously shows as an option on the neck slot even when WC isn't selected.