### PR TITLE
WC Wrath/Regret QL Level Fix

### DIFF
--- a/src/javascript/data/tswcalc-data-items.js
+++ b/src/javascript/data/tswcalc-data-items.js
@@ -192,6 +192,7 @@ tswcalc.data.items = [
     {
         id: '91',
         name: 'The Woodcutter\'s Regret',
+        ql: '10.9',
         role: 'tank',
         slots: ['neck'],
         glyph: {
@@ -215,6 +216,7 @@ tswcalc.data.items = [
     {
         id: '92',
         name: 'The Woodcutter\'s Wrath',
+        ql: '10.9',
         role: 'dps',
         slots: ['neck'],
         glyph: {


### PR DESCRIPTION
Uh... somehow I missed a QL level for the WC Wrath and WC Regret talismans. Fix for that.